### PR TITLE
Allow passing options to htmlcompressor

### DIFF
--- a/lib/middleman-minify-html/extension.rb
+++ b/lib/middleman-minify-html/extension.rb
@@ -1,12 +1,14 @@
 module Middleman
   class MinifyHtmlExtension < Extension
-    def initialize(*)
+    option :htmlcompressor_options, nil, 'Options hash to pass to Htmlcompressor'
+    
+    def initialize(app, options_hash={}, &block)
       super
       require 'htmlcompressor'
     end
 
     def after_configuration
-      app.use ::HtmlCompressor::Rack, options.to_h
+      app.use ::HtmlCompressor::Rack, options.htmlcompressor_options.to_h
     end
   end
 end


### PR DESCRIPTION
It seems as though passing options to htmlcompressor is broken in the latest release. What used to work:

```
activate :minify_html, {
  :remove_input_attributes => false
}
```

Gives an error about "Setting remove_input_attributes" does not exist.

With this patch settings can be set like this:

```
activate :minify_html, :htmlcompressor_options => {
  :remove_input_attributes => false
}
```

This may or may not be the desired behavior. It still breaks middleman apps that had settings set the old way, but it perhaps more verbosely indicates that they are now options for the htmlcompressor gem.
