### PR TITLE
Added compress_css and compress_javascript options

### DIFF
--- a/lib/middleman-minify-html/extension.rb
+++ b/lib/middleman-minify-html/extension.rb
@@ -33,8 +33,8 @@ module Middleman
     end
 
     def after_configuration
-      options[:javascript_compressor] = options[:javascript_compressor].call if options[:javascript_compressor].is_a?(Proc)
-      options[:css_compressor] = options[:css_compressor].call if options[:css_compressor].is_a?(Proc)
+      options[:javascript_compressor] = options[:javascript_compressor].call if options[:compress_javascript] && options[:javascript_compressor].is_a?(Proc)
+      options[:css_compressor] = options[:css_compressor].call if options[:compress_css] && options[:css_compressor].is_a?(Proc)
       app.use ::HtmlCompressor::Rack, options.to_h
     end
   end

--- a/lib/middleman-minify-html/extension.rb
+++ b/lib/middleman-minify-html/extension.rb
@@ -15,6 +15,17 @@ module Middleman
     option :remove_https_protocol, false, 'Remove HTTPS protocol'
     option :preserve_line_breaks, false, 'Preserve line breaks'
     option :simple_boolean_attributes, true, 'Use simple boolean attributes'
+    option :compress_css, false, 'Compress inline CSS'
+    option :compress_javascript, false, 'Compress inline JS'
+    # Similar to Middleman::Extensions::MinifyJavascript
+    option :javascript_compressor, proc {
+      require 'uglifier'
+      ::Uglifier.new
+    }, 'Set the JS compressor to use.'
+    option :css_compressor, proc {
+      require 'sass'
+      Middleman::Extensions::MinifyCss::SassCompressor
+    }, 'Set the CSS compressor to use.'
 
     def initialize(*)
       super
@@ -22,6 +33,8 @@ module Middleman
     end
 
     def after_configuration
+      options[:javascript_compressor] = options[:javascript_compressor].call if options[:javascript_compressor].is_a?(Proc)
+      options[:css_compressor] = options[:css_compressor].call if options[:css_compressor].is_a?(Proc)
       app.use ::HtmlCompressor::Rack, options.to_h
     end
   end


### PR DESCRIPTION
A different approach that would 'always' be compatible would me moving to a `option :config` that specifies the whole Htmlcompressor config.
